### PR TITLE
T5 - #2061 Correcting the behavior of DiagramServices

### DIFF
--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/DDiagramContents.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/DDiagramContents.java
@@ -298,7 +298,7 @@ public class DDiagramContents {
     ArrayList<DDiagramElement> result = new ArrayList<>();
     for (DDiagramElement view : getMapDiagramElements().get(target)) {
       DiagramElementMapping diagramElementMapping = view.getDiagramElementMapping();
-      if (mapping != null && mapping.equals(diagramElementMapping)) {
+      if (DiagramServices.getDiagramServices().isMapping(view, mapping)) {
         result.add(view);
       } else if (mapping instanceof IEdgeMapping && diagramElementMapping instanceof IEdgeMapping) {
         IEdgeMapping unwrappedMapping = EdgeMappingHelper.unwrapEdgeMapping((IEdgeMapping) mapping);

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/DDiagramContents.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/DDiagramContents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+ * Copyright (c) 2006, 2023 THALES GLOBAL SERVICES.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -30,8 +30,10 @@ import org.eclipse.sirius.diagram.DSemanticDiagram;
 import org.eclipse.sirius.diagram.DragAndDropTarget;
 import org.eclipse.sirius.diagram.description.DiagramDescription;
 import org.eclipse.sirius.diagram.description.DiagramElementMapping;
+import org.eclipse.sirius.diagram.description.IEdgeMapping;
 import org.eclipse.sirius.viewpoint.DSemanticDecorator;
 import org.polarsys.capella.common.helpers.EcoreUtil2;
+import org.polarsys.capella.core.sirius.analysis.helpers.EdgeMappingHelper;
 import org.polarsys.capella.core.sirius.analysis.tool.HashMapSet;
 
 /**
@@ -295,8 +297,15 @@ public class DDiagramContents {
 
     ArrayList<DDiagramElement> result = new ArrayList<>();
     for (DDiagramElement view : getMapDiagramElements().get(target)) {
-      if (mapping != null && mapping.equals(view.getDiagramElementMapping())) {
+      DiagramElementMapping diagramElementMapping = view.getDiagramElementMapping();
+      if (mapping != null && mapping.equals(diagramElementMapping)) {
         result.add(view);
+      } else if (mapping instanceof IEdgeMapping && diagramElementMapping instanceof IEdgeMapping) {
+        IEdgeMapping unwrappedMapping = EdgeMappingHelper.unwrapEdgeMapping((IEdgeMapping) mapping);
+        IEdgeMapping unwrappedDiagramElementMapping = EdgeMappingHelper.unwrapEdgeMapping((IEdgeMapping) diagramElementMapping);
+        if (unwrappedMapping.equals(unwrappedDiagramElementMapping)) {
+          result.add(view);
+        }
       }
     }
     return result;

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/DiagramServices.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/DiagramServices.java
@@ -1261,7 +1261,7 @@ public class DiagramServices {
     }
 
     public boolean validMapping(DiagramElementMapping mapping, DDiagramElement element) {
-      return isSameDomain(mapping, element) && mapping.equals(element.getDiagramElementMapping());
+      return isSameDomain(mapping, element) && checkMappingConsistency(mapping, element);
     }
 
     public boolean isSameDomain(DiagramElementMapping mapping, DDiagramElement element) {
@@ -1271,6 +1271,17 @@ public class DiagramServices {
         return true;
       }
       return false;
+    }
+
+    private boolean checkMappingConsistency(DiagramElementMapping mapping, DDiagramElement element) {
+      DiagramElementMapping elementMapping = element.getDiagramElementMapping();
+      if (mapping instanceof IEdgeMapping && elementMapping instanceof IEdgeMapping) {
+        IEdgeMapping unwrappedMapping = org.polarsys.capella.core.sirius.analysis.helpers.EdgeMappingHelper.unwrapEdgeMapping((IEdgeMapping) mapping);
+        IEdgeMapping unwrappedDiagramElementMapping = org.polarsys.capella.core.sirius.analysis.helpers.EdgeMappingHelper.unwrapEdgeMapping((IEdgeMapping) elementMapping);
+        return unwrappedMapping.equals(unwrappedDiagramElementMapping);
+      } else {
+        return mapping.equals(element.getDiagramElementMapping());
+      }
     }
 
   }

--- a/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/helpers/EdgeMappingHelper.java
+++ b/core/plugins/org.polarsys.capella.core.sirius.analysis/src/org/polarsys/capella/core/sirius/analysis/helpers/EdgeMappingHelper.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 THALES GLOBAL SERVICES and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ * 
+ * Contributors:
+ *    Obeo - initial API and implementation
+ *******************************************************************************/
+package org.polarsys.capella.core.sirius.analysis.helpers;
+
+import org.eclipse.sirius.diagram.description.IEdgeMapping;
+import org.eclipse.sirius.diagram.description.impl.EdgeMappingImportImpl;
+import org.eclipse.sirius.diagram.model.business.internal.description.spec.EdgeMappingImportWrapper;
+
+public class EdgeMappingHelper {
+
+  public static IEdgeMapping unwrapEdgeMapping(IEdgeMapping edgeMapping) {
+    if (edgeMapping instanceof EdgeMappingImportWrapper) {
+      return unwrapEdgeMapping(((EdgeMappingImportWrapper) edgeMapping).getWrappedEdgeMappingImport());
+    } else if (edgeMapping instanceof EdgeMappingImportImpl) {
+      return unwrapEdgeMapping(((EdgeMappingImportImpl) edgeMapping).getImportedMapping());
+    }
+    return edgeMapping;
+  }
+}


### PR DESCRIPTION
When DiagramServices tests an EdgeMapping for selection or visibility, the disconnect between EdgeMappingImpl and EdgeMappingWrapper is now managed, allowing easier integration of external features and plugins into Capella.